### PR TITLE
Update -u flag to --target-org since it is deprecated

### DIFF
--- a/LightningDeploy_INTEG.sh
+++ b/LightningDeploy_INTEG.sh
@@ -12,4 +12,4 @@ echo "+++++++++++++"
 files=$(git diff-tree --no-commit-id --name-only --diff-filter=AM -r $commitSHA | tr '\n' ',' | sed 's/,$//')
 echo "$files"
 
-sfdx force:source:deploy -p "$files" -u "INTEG"
+sfdx force:source:deploy -p "$files" --target-org INTEG


### PR DESCRIPTION
- use of --target-org instead of -u
- new string syntax (remove double quotes)